### PR TITLE
smart pointers

### DIFF
--- a/weak_ptr.cpp
+++ b/weak_ptr.cpp
@@ -1,0 +1,37 @@
+#include<iostream>
+#include<boost/shared_ptr.hpp>
+#include<boost/weak_ptr.hpp>
+
+using namespace std;
+
+
+int main()
+{
+	
+	
+	shared_ptr<int> f1(new int(9));				
+	cout<<"\nf1.get()	:"<<f1.get();
+	cout<<"\nf1.use_count()	:"<<f1.use_count();
+
+	int* p=f1.get();
+	cout<<"\n"<<*p<<"\n";
+
+	weak_ptr<int> w(f1);
+	shared_ptr<int> q=w.lock();				//now the object will stay alive until q goes out of scope or is reset
+	cout<<*q;
+
+	cout<<"\nf1.reset()";						
+	f1.reset();
+	cout<<"\n"<<*p;
+	cout<<"\n"<<*q<<"\n";
+
+	cout<<"q.reset";
+	q.reset();
+	cout<<"\n"<<*p;						//since the object doesn't exists now:output is segmentation fault 
+	cout<<"\n"<<*q<<"\n";
+
+						
+	return 0;
+
+}
+


### PR DESCRIPTION
from - http://en.cppreference.com/w/cpp/memory/weak_ptr

weak_ptr is a smart pointer that holds a non-owning ("weak") reference to an object that is managed by std::shared_ptr. It must be converted to std::shared_ptr in order to access the referenced object.

std::weak_ptr is used to track the object, and it is converted to std::shared_ptr to assume temporary ownership. If the original std::shared_ptr is destroyed at this time, the object's lifetime is extended until the temporary std::shared_ptr is destroyed as well. 